### PR TITLE
기능 :: 키와 리전을 직접 입력하도록 변경

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,9 +7,9 @@ import { useRef } from 'react';
 export default function Home() {
   const mimiRef = useRef<MimiHandle>(null);
 
-  const handleSubmit = (voice: string, expressStyle: string, rate: string, pitch: string, phrase: string) => {
+  const handleSubmit = (speechKey: string, speechRegion: string, voice: string, expressStyle: string, rate: string, pitch: string, phrase: string) => {
     if (!mimiRef.current) return;
-    mimiRef.current.activeMimi(voice, expressStyle, phrase, rate, pitch);
+    mimiRef.current.activeMimi(speechKey, speechRegion, voice, expressStyle, phrase, rate, pitch);
   }
 
   return (

--- a/components/Mimi.tsx
+++ b/components/Mimi.tsx
@@ -9,11 +9,11 @@ const Mimi = (props: {}, ref: ForwardedRef<MimiHandle>) => {
   const ttsAudioRef = useRef<HTMLAudioElement | null>(null);
   
   useImperativeHandle(ref, () => ({
-    async activeMimi(voice, expressStyle, phrase, rate, pitch) {
+    async activeMimi(speechKey, speechRegion, voice, expressStyle, phrase, rate, pitch) {
       try {
-        if (!voice || !expressStyle || !phrase || !rate || !pitch) return;
+        if (!speechKey || !speechRegion || !voice || !expressStyle || !phrase || !rate || !pitch) return;
         try {
-          const result = await texttospeech(voice, expressStyle, phrase, rate, pitch);
+          const result = await texttospeech(speechKey, speechRegion, voice, expressStyle, phrase, rate, pitch);
           if (!result) throw new Error('음성 합성 실패');
 
           const { audio, visemes } = result;

--- a/components/forms/TextToSpeechForm.tsx
+++ b/components/forms/TextToSpeechForm.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 interface TextToSpeechFormProps {
-  onSubmit: (voice: string, expressStyle: string, rate: string, pitch: string, phrase: string) => void;
+  onSubmit: (speechKey: string, speechRegion: string, voice: string, expressStyle: string, rate: string, pitch: string, phrase: string) => void;
 }
 
 export default function TextToSpeechForm({ onSubmit }: TextToSpeechFormProps) {
@@ -9,17 +9,21 @@ export default function TextToSpeechForm({ onSubmit }: TextToSpeechFormProps) {
     e.preventDefault();
 
     const formData = new FormData(e.target as HTMLFormElement); 
+    const speechKey = formData.get('speechKey') as string;
+    const speechRegion = formData.get('speechRegion') as string;
     const voice = formData.get('voice') as string;
     const expressStyle = formData.get('expressStyle') as string;
     const rate = formData.get('rate') as string;
     const pitch = formData.get('pitch') as string;
     const phrase = formData.get('phrase') as string;
 
-    onSubmit(voice, expressStyle, rate, pitch, phrase);
+    onSubmit(speechKey, speechRegion, voice, expressStyle, rate, pitch, phrase);
   }
   
   return (
     <form className="flex flex-col gap-4 w-full max-w-xl h-full" onSubmit={handleSubmit}>
+      <input type="text" name="speechKey" className="w-full p-2 border border-gray-700 focus:bg-gray-400/10 rounded-lg" placeholder="speech key" />
+      <input type="text" name="speechRegion" className="w-full p-2 border border-gray-700 focus:bg-gray-400/10 rounded-lg" placeholder="speech region" />
       <select name="voice" className="w-full px-1 py-2 border border-gray-700 rounded-lg">
         <option className="p-2 bg-white" value="en-US-JasonNeural">US: Jason</option>
         <option className="p-2 bg-white" value="en-US-CoraNeural">US: Cora</option>

--- a/libs/texttospeech.ts
+++ b/libs/texttospeech.ts
@@ -2,9 +2,6 @@
 
 import { SpeechConfig, AudioConfig, SpeakerAudioDestination, SpeechSynthesizer, ResultReason, SpeechSynthesisResult } from 'microsoft-cognitiveservices-speech-sdk';
 
-const SPEECH_KEY = process.env.NEXT_PUBLIC_SPEECH_KEY!;
-const SPEECH_REGION = process.env.NEXT_PUBLIC_SPEECH_REGION!;
-
 interface TextToSpeechResult {
   audio: Blob;
   visemes: Viseme[];
@@ -12,16 +9,18 @@ interface TextToSpeechResult {
 
 /**
  * 텍스트를 음성으로 변환하고 시각화 데이터를 반환합니다.
+ * @param speechKey 음성 키
+ * @param speechRegion 음성 지역
  * @param voice 음성 이름
  * @param expressStyle 음성 스타일
  * @param phrase 텍스트
  * @returns 음성 데이터와 시각화 데이터
  */
-const texttospeech = async (voice: string, expressStyle: string, phrase: string, rate: string, pitch: string): Promise<TextToSpeechResult> => {
+const texttospeech = async (speechKey: string, speechRegion: string, voice: string, expressStyle: string, phrase: string, rate: string, pitch: string): Promise<TextToSpeechResult> => {
   return new Promise((resolve, reject) => {
     // Synthesizer 객체 생성
     const audioDestination = new SpeakerAudioDestination();    
-    const speechConfig = SpeechConfig.fromSubscription(SPEECH_KEY, SPEECH_REGION);
+    const speechConfig = SpeechConfig.fromSubscription(speechKey, speechRegion);
     const audioConfig = AudioConfig.fromSpeakerOutput(audioDestination);
     const synthesizer = new SpeechSynthesizer(speechConfig, audioConfig);
 

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -1,5 +1,7 @@
 interface MimiHandle {
   activeMimi: (
+    speechKey: string,
+    speechRegion: string,
     voice: string,
     expressStyle: string,
     phrase: string,


### PR DESCRIPTION
## Sourcery 요약

본 풀 리퀘스트는 사용자가 환경 변수에 의존하는 대신 음성 키와 지역을 직접 입력할 수 있도록 텍스트 음성 변환 기능을 수정합니다. 이 변경으로 텍스트 음성 변환 기능의 유연성과 사용성이 향상됩니다.

새로운 기능:
- 사용자가 음성 키와 지역을 폼에 직접 입력할 수 있습니다.

개선 사항:
- 음성 키와 지역을 파라미터로 받도록 텍스트 음성 변환 기능을 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

This pull request modifies the text-to-speech functionality to allow users to directly input their speech key and region, instead of relying on environment variables. This change enhances the flexibility and usability of the text-to-speech feature.

New Features:
- Allows users to input their speech key and region directly in the form.

Enhancements:
- Updates the text-to-speech function to accept speech key and region as parameters.

</details>